### PR TITLE
Fix: Add object to reservation

### DIFF
--- a/src/reservation/reservation.controllers.js
+++ b/src/reservation/reservation.controllers.js
@@ -18,7 +18,7 @@ export async function createReservation(req, res) {
   });
 
   const { host: hostId, title: objTitle } = await Offer.findById(
-    req.body.objectId,
+    req.body.object,
   );
   const { email } = await User.findById(hostId);
 


### PR DESCRIPTION
Teraz normalnie łapie w bazie danych dodanie obiektu do rezerwacji w mongoDB. Stworzone są przykłady też.